### PR TITLE
Change skin path to use Composer's path

### DIFF
--- a/ArchiWiki.skin.php
+++ b/ArchiWiki.skin.php
@@ -5,7 +5,7 @@
  * @ingroup Skins
  */
 class SkinArchiWiki extends SkinTemplate {
-	public $skinname = 'archiwiki', $stylename = 'ArchiWiki',
+	public $skinname = 'archiwiki', $stylename = 'archi-wiki',
 		$template = 'ArchiWikiTemplate', $useHeadElement = true;
 
 	/**


### PR DESCRIPTION
Hello,

Composer refuse le camel-case et donc installe le skin dans `skins/archi-wiki/`. Du coup, il faudrait utiliser la même chose dans la classe sinon certaines ressources ne se chargent pas.
Mais il faudra probablement que tu renommes le dossier du skin en local aussi.