### PR TITLE
Bower name is recommended to be lowercase

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ArchiWiki",
+  "name": "archi-wiki-skin",
   "description": "Theme for ArchiWiki",
   "main": "",
   "authors": [


### PR DESCRIPTION
Cette PR corrige cet avertissement : 
```
bower                     invalid-meta for:/home/pierre/www/archi-mediawiki/skins/archi-wiki/bower.json
bower                     invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes
```
(J'essaie de réduire la verbosité de mon script de déploiement.)